### PR TITLE
1 nested css error

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,8 @@
 module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
+  plugins: [
+    require('postcss-import'),
+    require('tailwindcss/nesting')(require('postcss-nesting')),
+    require('autoprefixer'),
+    require('tailwindcss'),
+  ]
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,8 +1,8 @@
 module.exports = {
   plugins: [
-    require('postcss-import'),
-    require('tailwindcss/nesting')(require('postcss-nesting')),
-    require('autoprefixer'),
-    require('tailwindcss'),
+      'postcss-import',
+      'tailwindcss/nesting',
+      'tailwindcss',
+      'autoprefixer',
   ]
 }


### PR DESCRIPTION
1. Installed postcss-nesting: ```npm install postcss-nesting```
2. New postcss.config.js : 

```
module.exports = {
  plugins: [
      'postcss-import',
      'tailwindcss/nesting',
      'tailwindcss',
      'autoprefixer',
  ]
}
```
